### PR TITLE
Improve loading time of unet models by 80%

### DIFF
--- a/deepfloyd_if/modules/base.py
+++ b/deepfloyd_if/modules/base.py
@@ -12,6 +12,7 @@ import torchvision.transforms as T
 from PIL import Image
 from omegaconf import OmegaConf
 from huggingface_hub import hf_hub_download
+from accelerate.utils import set_module_tensor_to_device
 
 
 from .. import utils
@@ -232,7 +233,10 @@ class IFBaseModule:
         path = self._get_path_or_download_file_from_hf(dir_or_name, filename)
         if os.path.exists(path):
             checkpoint = torch.load(path, map_location='cpu')
-            model.load_state_dict(checkpoint)
+            param_device = "cpu"
+
+            for param_name, param in checkpoint.items():
+                set_module_tensor_to_device(model, param_name, param_device, value=param)
         else:
             print(f'Warning! In directory "{dir_or_name}" filename "pytorch_model.bin" is not found.')
         return model

--- a/deepfloyd_if/modules/stage_I.py
+++ b/deepfloyd_if/modules/stage_I.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .base import IFBaseModule
 from ..model import UNetModel
+import accelerate
 
 
 class IFStageI(IFBaseModule):
@@ -17,8 +18,12 @@ class IFStageI(IFBaseModule):
         super().__init__(*args, pil_img_size=pil_img_size, **kwargs)
         model_params = dict(self.conf.params)
         model_params.update(model_kwargs or {})
-        self.model = UNetModel(**model_params).eval().to(self.device)
+
+        with accelerate.init_empty_weights():
+            self.model = UNetModel(**model_params)
+
         self.model = self.load_checkpoint(self.model, self.dir_or_name)
+        self.model.eval().to(self.device)
 
     def embeddings_to_image(self, t5_embs, style_t5_embs=None, positive_t5_embs=None, negative_t5_embs=None,
                             batch_repeat=1, dynamic_thresholding_p=0.95, sample_loop='ddpm', positive_mixer=0.25,


### PR DESCRIPTION
Given the size of the unets I strongly recommend to make use of `accelerate` to speed-up the model loading time. 
Since you use `accelerate` anyways in your setup we can use it as well to speed up the loading time of the unets (by skipping random init) just like it's automatically done for T5. 

With this PR you reduce the following code snippet:
```py
from deepfloyd_if.modules import IFStageI
from time import time

start_time = time()
model = IFStageI(dir_or_name="/home/patrick/IF-I-IF-v1.0/", device="cuda")
print("Time", time() - start_time)
```

From ~50 seconds to just 8 seconds. This really makes a difference when playing with the model. 

Maybe this helps :-) 

Amazing work with the model overall - the accuracy of image generation is really impressive! 