### PR TITLE
Fix sci-kit

### DIFF
--- a/deepfloyd_if/pipelines/inpainting.py
+++ b/deepfloyd_if/pipelines/inpainting.py
@@ -58,7 +58,7 @@ def inpainting(
 
     if_I_kwargs['support_noise'] = low_res
 
-    inpainting_mask_I = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w)))
+    inpainting_mask_I = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w), anti_aliasing=True))
     inpainting_mask_I = torch.from_numpy(inpainting_mask_I).unsqueeze(0).to(if_I.device)
 
     if_I_kwargs['inpainting_mask'] = inpainting_mask_I
@@ -81,7 +81,7 @@ def inpainting(
         if_II_kwargs['support_noise'] = mid_res
 
         if 'inpainting_mask' not in if_II_kwargs:
-            inpainting_mask_II = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w)))
+            inpainting_mask_II = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w), anti_aliasing=True))
             inpainting_mask_II = torch.from_numpy(inpainting_mask_II).unsqueeze(0).to(if_II.device)
             if_II_kwargs['inpainting_mask'] = inpainting_mask_II
 
@@ -110,7 +110,7 @@ def inpainting(
             if_III_kwargs['support_noise'] = high_res
 
             if 'inpainting_mask' not in if_III_kwargs:
-                inpainting_mask_III = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w)))
+                inpainting_mask_III = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w), anti_aliasing=True))
                 inpainting_mask_III = torch.from_numpy(inpainting_mask_III).unsqueeze(0).to(if_III.device)
                 if_III_kwargs['inpainting_mask'] = inpainting_mask_III
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tokenizers~=0.13.2
 sentencepiece~=0.1.97
 ftfy~=6.1.1
 beautifulsoup4~=4.11.1
+scikit-image>=0.22.0


### PR DESCRIPTION
For inpainting fixing:
```
python
File /usr/local/lib/python3.10/dist-packages/deepfloyd_if/pipelines/inpainting.py:61, in inpainting(t5, if_I, if_II, if_III, support_pil_img, prompt, inpainting_mask, negative_prompt, seed, if_I_kwargs, if_II_kwargs, if_III_kwargs, progress, return_tensors, disable_watermark)
     57 if_I_kwargs['negative_t5_embs'] = negative_t5_embs
     59 if_I_kwargs['support_noise'] = low_res
---> 61 inpainting_mask_I = img_as_bool(resize(inpainting_mask[0].cpu(), (3, image_h, image_w)))
     62 inpainting_mask_I = torch.from_numpy(inpainting_mask_I).unsqueeze(0).to(if_I.device)
     64 if_I_kwargs['inpainting_mask'] = inpainting_mask_I

File /usr/local/lib/python3.10/dist-packages/skimage/transform/_warps.py:154, in resize(image, output_shape, order, mode, cval, clip, preserve_range, anti_aliasing, anti_aliasing_sigma)
    149     image = image.astype(np.float32)
    151 if anti_aliasing is None:
    152     anti_aliasing = (
    153         not input_type == bool and
--> 154         not (np.issubdtype(input_type, np.integer) and order == 0) and
    155         any(x < y for x, y in zip(output_shape, input_shape)))
    157 if input_type == bool and anti_aliasing:
    158     raise ValueError("anti_aliasing must be False for boolean images")

File /usr/local/lib/python3.10/dist-packages/numpy/core/numerictypes.py:416, in issubdtype(arg1, arg2)
    358 r"""
    359 Returns True if first argument is a typecode lower/equal in type hierarchy.
    360 
   (...)
    413 
    414 """
    415 if not issubclass_(arg1, generic):
--> 416     arg1 = dtype(arg1).type
    417 if not issubclass_(arg2, generic):
    418     arg2 = dtype(arg2).type

TypeError: Cannot interpret 'torch.int32' as a data type
```